### PR TITLE
Harden Markdown anchor validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Notable changes to this project are recorded here.
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-08-07
+
+- Replace regular-expression HTML-tag removal in Markdown anchor validation with a single-pass parser.
+- Add regression coverage for nested markup and duplicate heading anchors.
+
 ## [1.0.0] - 2026-08-07
 
 - Publish the initial open-source release of this FDE field guide.
@@ -11,5 +16,6 @@ Notable changes to this project are recorded here.
 - Add a transactional invoice-exception reference with executable policy, runtime, contract, and adversarial replay tests.
 - Add a dated evidence ledger with explicit source-quality and claim boundaries.
 
-[Unreleased]: https://github.com/davidahmann/production-agent-engineering/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/davidahmann/production-agent-engineering/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/davidahmann/production-agent-engineering/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/davidahmann/production-agent-engineering/releases/tag/v1.0.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ authors:
 repository-code: "https://github.com/davidahmann/production-agent-engineering"
 url: "https://github.com/davidahmann/production-agent-engineering"
 license: Apache-2.0
-version: 1.0.0
+version: 1.0.1
 date-released: 2026-08-07
 abstract: "Machine-readable controls, architecture blueprints, evaluation contracts, security patterns, runbooks, and executable reference behavior for production AI agents."
 keywords:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "production-agent-engineering",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "production-agent-engineering",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "ajv": "8.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "production-agent-engineering",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "FDE field guide and executable reference kit for production AI agents.",
   "private": true,
   "license": "Apache-2.0",
@@ -31,11 +31,12 @@
   },
   "scripts": {
     "validate": "node scripts/validate-repository.mjs",
+    "test:markdown": "node --test tests/markdown-anchors.test.mjs",
     "test:contracts": "node --test tests/schema-contracts.test.mjs",
     "test:policy": "node --test examples/invoice-exception/authorization-policy.test.mjs",
     "test:reference": "node --test examples/invoice-exception/reference-loop.test.mjs",
     "test:evals": "node --test examples/invoice-exception/run-evals.test.mjs",
-    "test": "npm run validate && npm run test:contracts && npm run test:policy && npm run test:reference && npm run test:evals"
+    "test": "npm run validate && npm run test:markdown && npm run test:contracts && npm run test:policy && npm run test:reference && npm run test:evals"
   },
   "devDependencies": {
     "ajv": "8.20.0",

--- a/scripts/markdown-anchors.mjs
+++ b/scripts/markdown-anchors.mjs
@@ -1,0 +1,43 @@
+export function stripHtmlTags(value) {
+  let output = "";
+  let insideTag = false;
+
+  for (const character of value) {
+    if (character === "<") {
+      insideTag = true;
+      continue;
+    }
+    if (character === ">") {
+      insideTag = false;
+      continue;
+    }
+    if (!insideTag) output += character;
+  }
+
+  return output;
+}
+
+export function githubSlug(value) {
+  return stripHtmlTags(value)
+    .trim()
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s_-]/gu, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-");
+}
+
+export function markdownAnchors(content) {
+  const anchors = new Set();
+  for (const match of content.matchAll(/<a\s+(?:name|id)=["']([^"']+)["'][^>]*>/gi)) anchors.add(match[1]);
+  for (const line of content.split("\n")) {
+    const match = /^(#{1,6})\s+(.+?)\s*$/.exec(line);
+    if (!match) continue;
+    const base = githubSlug(match[2]);
+    if (!base) continue;
+    let candidate = base;
+    let suffix = 1;
+    while (anchors.has(candidate)) candidate = `${base}-${suffix++}`;
+    anchors.add(candidate);
+  }
+  return anchors;
+}

--- a/scripts/validate-repository.mjs
+++ b/scripts/validate-repository.mjs
@@ -9,6 +9,7 @@ import Ajv2020 from "ajv/dist/2020.js";
 import addFormats from "ajv-formats";
 
 import { embeddedToolSchemaErrors, ontologyIdentityErrors, patternCatalogErrors } from "./contract-invariants.mjs";
+import { markdownAnchors } from "./markdown-anchors.mjs";
 
 const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 const ignoredDirectories = new Set([".git", "node_modules", "coverage"]);
@@ -34,32 +35,6 @@ async function walk(directory) {
 
 function relative(file) {
   return path.relative(root, file).split(path.sep).join("/");
-}
-
-function githubSlug(value) {
-  return value
-    .trim()
-    .toLowerCase()
-    .replace(/<[^>]+>/g, "")
-    .replace(/[^\p{L}\p{N}\s_-]/gu, "")
-    .replace(/\s+/g, "-")
-    .replace(/-+/g, "-");
-}
-
-function markdownAnchors(content) {
-  const anchors = new Set();
-  for (const match of content.matchAll(/<a\s+(?:name|id)=["']([^"']+)["'][^>]*>/gi)) anchors.add(match[1]);
-  for (const line of content.split("\n")) {
-    const match = /^(#{1,6})\s+(.+?)\s*$/.exec(line);
-    if (!match) continue;
-    const base = githubSlug(match[2]);
-    if (!base) continue;
-    let candidate = base;
-    let suffix = 1;
-    while (anchors.has(candidate)) candidate = `${base}-${suffix++}`;
-    anchors.add(candidate);
-  }
-  return anchors;
 }
 
 function collectControlIds(value, ids = new Set()) {
@@ -190,6 +165,9 @@ if (packageMetadata) {
   if (packageMetadata.private !== true) fail("package.json must prevent accidental registry publication");
   if (packageMetadata.repository?.url !== "git+https://github.com/davidahmann/production-agent-engineering.git") {
     fail("package.json has a non-canonical repository URL");
+  }
+  if (!citation.includes(`version: ${packageMetadata.version}`)) {
+    fail("CITATION.cff version does not match package.json");
   }
 }
 

--- a/tests/markdown-anchors.test.mjs
+++ b/tests/markdown-anchors.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { githubSlug, markdownAnchors, stripHtmlTags } from "../scripts/markdown-anchors.mjs";
+
+test("GitHub-style slugs normalize punctuation and whitespace", () => {
+  assert.equal(githubSlug("  Production Agent Engineering!  "), "production-agent-engineering");
+});
+
+test("inline HTML tags are removed without re-forming nested markup", () => {
+  assert.equal(stripHtmlTags("Use <em>bounded</em> tools"), "Use bounded tools");
+  assert.equal(githubSlug("<<script>>alert</script>"), "alert");
+  assert.doesNotMatch(githubSlug("<<script>>alert</script>"), /[<>]/);
+});
+
+test("duplicate headings and explicit anchors receive stable unique slugs", () => {
+  const anchors = markdownAnchors([
+    "# Release gate",
+    "# Release gate",
+    '<a id="release-gate-2"></a>',
+    "# Release gate",
+  ].join("\n"));
+
+  assert.deepEqual([...anchors], ["release-gate-2", "release-gate", "release-gate-1", "release-gate-3"]);
+});


### PR DESCRIPTION
## Outcome

Resolve the high-severity CodeQL finding in Markdown anchor normalization without dismissing it as a contextual false positive.

## Changes

- replace multi-character regex tag removal with a single-pass tag parser
- isolate and export Markdown anchor helpers
- add regression tests for inline HTML, nested markup, and duplicate anchors
- keep package and citation versions aligned at v1.0.1

## Verification

- npm ci --ignore-scripts
- npm test
- npm audit --audit-level=high
- actionlint
- CFF 1.2 validation
- Gitleaks
- git diff --check

## Risk and rollback

The helper is used only for repository Markdown-link validation. Rollback is the prior validator implementation; the added tests preserve expected slug behavior.