### PR TITLE
Add FDE and AI engineer capability roadmap

### DIFF
--- a/.github/ISSUE_TEMPLATE/field-signal.yml
+++ b/.github/ISSUE_TEMPLATE/field-signal.yml
@@ -1,0 +1,70 @@
+name: Field signal or learning resource
+description: Suggest one anonymized FDE lesson, failure pattern, useful resource, or missing capability topic.
+title: "[Field signal]: "
+labels:
+  - triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Share one focused signal. Do not include customer names, private data, credentials, employer-confidential material, or vulnerability details. Use SECURITY.md for vulnerabilities.
+  - type: dropdown
+    id: signal_type
+    attributes:
+      label: Signal type
+      options:
+        - Anonymized delivery lesson
+        - Failure or anti-pattern
+        - Learning resource
+        - Missing capability or practice topic
+        - Terminology or role clarification
+    validations:
+      required: true
+  - type: textarea
+    id: signal
+    attributes:
+      label: What should practitioners learn?
+      description: State the lesson in your own words and keep it to one bounded claim.
+    validations:
+      required: true
+  - type: textarea
+    id: relevance
+    attributes:
+      label: Why it matters for FDE or applied-AI work
+      description: Explain which workflow, decision, delivery stage, failure, or operating responsibility it improves.
+    validations:
+      required: true
+  - type: dropdown
+    id: evidence_type
+    attributes:
+      label: Evidence type
+      options:
+        - Direct experience, anonymized
+        - Primary source or reproducible artifact
+        - Secondary source or practitioner commentary
+        - Question or hypothesis needing evidence
+    validations:
+      required: true
+  - type: input
+    id: source
+    attributes:
+      label: Source URL or public artifact
+      description: Optional for anonymized experience; use a stable public URL when the signal comes from a source.
+  - type: textarea
+    id: limits
+    attributes:
+      label: Limits and context
+      description: State where this may not transfer, what remains uncertain, and any vendor or environment dependency.
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Submission checks
+      options:
+        - label: I removed customer, employer-confidential, personal, credential, and security-sensitive information.
+          required: true
+        - label: I have the right to submit this text and have disclosed any affiliation or commercial interest in the description.
+          required: true
+        - label: I understand this is a research lead, not production evidence, authority, or an automatic repository recommendation.
+          required: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This repository is a design and verification kit for production AI-enabled syste
 
 Treat an agent as one component option. For each consequential decision, first compare deterministic code, optimization, classical ML, retrieval, a foundation-model call, a bounded agent workflow, and human review as applicable. Select the smallest sufficient mechanism and preserve the authority, evidence, cost, fallback, and retirement rationale. `ARC-004`, `ARC-005`.
 
-Use [`README.md`](README.md) for the public entry door, the concise [`guide/README.md`](guide/README.md) for the human mental model, and this file as the working contract for repository navigation and changes.
+Use [`README.md`](README.md) for the public entry door, the concise [`guide/README.md`](guide/README.md) for the human mental model, [`guide/capability-roadmap.md`](guide/capability-roadmap.md) for role and practice orientation, and this file as the working contract for repository navigation and changes.
 
 ## Required orientation
 
@@ -25,7 +25,7 @@ Do not load the entire repository by default. Use one skill or task route, then 
 
 | Path | Role | Treat it as |
 | --- | --- | --- |
-| [`guide/`](guide/README.md) | Gives a concise, linear explanation of the FDE method | Human orientation; narrative, not a normative production contract |
+| [`guide/`](guide/README.md) | Gives a concise explanation of the FDE method plus a role and practice roadmap | Human orientation; narrative, not a certification or normative production contract |
 | [`catalog.json`](catalog.json) | Lists governed artifacts, types, paths, and tags | Registry; update when a cataloged artifact is added, moved, or removed |
 | [`controls/`](controls/control-catalog.json) | Defines production requirements and release gates | Engineering policy normative within this guide |
 | [`schemas/`](schemas/README.md) | Defines valid structures for machine-readable artifacts | Structural source of truth |
@@ -66,6 +66,7 @@ Repository-local skills are instruction-only workflows. They grant no tool acces
 | Task | Read next | Expected result |
 | --- | --- | --- |
 | Learn or explain the method | [Concise FDE Guide](guide/README.md) → relevant Handbook or Engineering Kit link | Shared mental model without loading the complete repository |
+| Learn or assess FDE and AI-engineering capability | [Capability roadmap](guide/capability-roadmap.md) → one relevant practice mission → linked canonical artifacts | Role boundaries, capability gaps, and inspectable practice evidence without treating the roadmap as a hiring standard or production proof |
 | Lead an FDE or internal delivery engagement | [Concise FDE Guide](guide/README.md) when orientation is needed → [FDE playbooks](playbooks/README.md) → current lifecycle stage → required templates | Evidence-backed decisions from qualification through business-owned production operation |
 | Review an FDE or applied-AI portfolio | [Operate and Scale](playbooks/03-operate-and-scale.md) → [portfolio review](templates/fde-portfolio-review.md) → linked service reviews and field-learning records | Cohort-aware investment, continuation, productization, transfer, capacity, and exit decisions without overriding workflow gates |
 | Build shared applied-AI capability | [FDE and applied AI engineering synthesis](library/10-fde-and-production-agent-synthesis.md) → current lifecycle stage → relevant reusable artifact | A deliberate boundary between workflow-specific delivery, reusable product/platform capability, and sanitized field learning |
@@ -118,6 +119,7 @@ Do not begin with multi-agent topology or framework selection. First establish t
 - Executable tests provide regression evidence for the behavior they exercise; passing does not certify production readiness.
 - Blueprints and templates translate controls into reusable designs.
 - The concise Guide explains the shared mental model and routes readers to authoritative deeper artifacts.
+- The capability roadmap organizes learning and assessment over the same method; it is not a certification, production gate, or substitute for target evidence.
 - Library pages explain the reasoning; research records the evidence and its limits.
 
 If these disagree, do not silently choose one. Identify the conflict, preserve the safer behavior, and update every affected layer in the same change when feasible.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes to this project are recorded here.
 
 ## [Unreleased]
 
+- Add a compact FDE and AI engineer capability roadmap with role boundaries, eight capability domains, four evidence-backed practice missions, a five-part engagement starter pack, assessment prompts, and a concise glossary.
+- Publish the roadmap as a focused web route and integrate it into human, agent, catalog, contribution, and maintainer navigation without creating a parallel method.
+- Add a low-friction field-signal issue form for anonymized lessons, failure patterns, learning resources, and capability gaps while preserving confidentiality and evidence boundaries.
+
 ## [1.12.0] - 2026-08-10
 
 - Add a generated GitHub Pages guide with focused reader routes, accessible navigation, local search, canonical and social metadata, structured data, sitemap, crawler policy, and a machine-readable web index without creating a second content corpus.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,12 @@ Repository skills live under [`.agents/skills/`](.agents/skills/) and remain thi
 - be registered in [`catalog.json`](catalog.json) and covered by `npm run test:skills`;
 - update `README.md`, `guide/README.md`, `AGENTS.md`, and `llms.txt` when public navigation or the shared method changes.
 
+## Suggest a field signal or learning resource
+
+Use the focused [field-signal form](https://github.com/davidahmann/fde-guide/issues/new?template=field-signal.yml) for one anonymized delivery lesson, failure pattern, useful practitioner resource, or missing capability topic. This is the lowest-friction contribution path; you do not need to propose a control, schema, or implementation.
+
+Explain why the signal matters to FDE or applied-AI work, state whether it comes from direct experience or a source, and keep the claim no broader than the evidence. Do not include customer names, employer-confidential material, private data, credentials, or a disguised vendor pitch. A submitted signal is a research lead, not authority, target evidence, or an automatic roadmap addition.
+
 ## Pull requests
 
 Keep each pull request reviewable and scoped to one outcome. Explain:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An independent, open-source guide and engineering kit for forward deployed engin
 [![Latest release](https://img.shields.io/github/v/release/davidahmann/fde-guide)](https://github.com/davidahmann/fde-guide/releases/latest)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 
-[Read on the web](https://davidahmann.github.io/fde-guide/) · [Read the concise Guide](guide/README.md) · [Use the Handbook](playbooks/README.md) · [Run the code](#see-it-working) · [Browse solutions](solutions/README.md) · [Use with an agent](#optional-use-it-with-a-coding-agent)
+[Read on the web](https://davidahmann.github.io/fde-guide/) · [Read the concise Guide](guide/README.md) · [Build FDE capability](guide/capability-roadmap.md) · [Use the Handbook](playbooks/README.md) · [Run the code](#see-it-working) · [Browse solutions](solutions/README.md) · [Use with an agent](#optional-use-it-with-a-coding-agent)
 
 ## Choose your depth
 
@@ -18,11 +18,13 @@ This is one method at three levels. Start with only the depth your job requires.
 
 | Layer | Use it when | Start here |
 | --- | --- | --- |
-| **The Guide** | You want the mental model, core principles, and complete FDE delivery loop in about 20 minutes | [Read the concise Guide](guide/README.md) |
+| **The Guide** | You want the mental model, core principles, complete FDE delivery loop, or a practical path for building capability | [Read the concise Guide](guide/README.md) or follow the [FDE and AI engineer capability roadmap](guide/capability-roadmap.md) |
 | **The Handbook** | You are qualifying, designing, delivering, transferring, or operating a real workflow | [Follow the lifecycle playbooks](playbooks/README.md) and [human-readable library](library/00-start-here.md) |
 | **The Engineering Kit** | You need implementation artifacts, architecture, machine-readable contracts, release controls, executable examples, or tests | [Inspect the kit](#what-is-in-the-engineering-kit), [controlled-write system](examples/invoice-exception/README.md), and [hybrid system](examples/shipment-risk-triage/README.md) |
 
 The Guide explains the method. The Handbook supports judgment. The Engineering Kit makes claims, authority, behavior, and changes inspectable and testable. They are not separate frameworks.
+
+New to the role or assessing a team? The [capability roadmap](guide/capability-roadmap.md) compares adjacent responsibilities, organizes the work into eight capability domains, and provides four evidence-backed practice missions, a five-part starter pack, and a concise glossary. It is a learning route over this method—not a certification or separate framework.
 
 ## The core idea: engineer value before autonomy
 
@@ -60,6 +62,7 @@ The examples are in-memory teaching systems, not deployable products. Their test
 
 | You own | Start with | You should leave with |
 | --- | --- | --- |
+| Learning, hiring, or capability development | [FDE and AI engineer capability roadmap](guide/capability-roadmap.md) → one practice mission | Role boundaries, capability gaps, starter artifacts, and inspectable evidence without a stack-first curriculum |
 | Business value or use-case selection | [Concise Guide](guide/README.md) → [Discovery and Value](playbooks/01-discovery-and-value.md) | Bounded workflow, baseline, accepted outcome, verifier, value case, guardrails, and decision |
 | FDE or internal applied-AI delivery | [Handbook](playbooks/README.md) → current lifecycle stage | Evidence-backed path from observation through adoption, handoff, operation, and field learning |
 | AI engineering or software architecture | [Intelligence selection](library/12-software-architecture-and-intelligence-selection.md) → [blueprints](blueprints/README.md) | Smallest sufficient mechanism, coherent system boundary, contracts, failure behavior, and test plan |
@@ -178,7 +181,7 @@ git diff --check
 
 ## Contribute
 
-Start with [CONTRIBUTING.md](CONTRIBUTING.md). Use [Discussions](https://github.com/davidahmann/fde-guide/discussions) for design questions, [Issues](https://github.com/davidahmann/fde-guide/issues) for reproducible defects or evidence corrections, and the private channel in [SECURITY.md](SECURITY.md) for vulnerabilities.
+Start with [CONTRIBUTING.md](CONTRIBUTING.md). Use [Discussions](https://github.com/davidahmann/fde-guide/discussions) for design questions, the focused [field-signal form](https://github.com/davidahmann/fde-guide/issues/new?template=field-signal.yml) to suggest an anonymized lesson or learning resource, [Issues](https://github.com/davidahmann/fde-guide/issues) for reproducible defects or evidence corrections, and the private channel in [SECURITY.md](SECURITY.md) for vulnerabilities.
 
 Maintained by [David Ahmann](https://github.com/davidahmann) ([LinkedIn](https://www.linkedin.com/in/dahmann/)), a cloud, data, and AI platform leader with Field CTO experience. This is an independent project; no current or former employer endorsement is implied.
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -3,6 +3,7 @@
 | Need | Channel |
 | --- | --- |
 | Architecture or implementation question | [GitHub Discussions](https://github.com/davidahmann/fde-guide/discussions) |
+| Anonymized field lesson, failure pattern, learning resource, or capability gap | [Field signal](https://github.com/davidahmann/fde-guide/issues/new?template=field-signal.yml) |
 | Reproducible repository defect | [Bug report](https://github.com/davidahmann/fde-guide/issues/new?template=bug.yml) |
 | Control, pattern, or blueprint proposal | [Design proposal](https://github.com/davidahmann/fde-guide/issues/new?template=design-proposal.yml) |
 | Incorrect or stale evidence | [Evidence correction](https://github.com/davidahmann/fde-guide/issues/new?template=evidence-correction.yml) |

--- a/catalog.json
+++ b/catalog.json
@@ -10,6 +10,12 @@
       "tags": ["fde", "value", "architecture", "lifecycle"]
     },
     {
+      "id": "guide.capability-roadmap",
+      "type": "standard",
+      "path": "guide/capability-roadmap.md",
+      "tags": ["fde", "ai-engineering", "capability", "learning"]
+    },
+    {
       "id": "controls.production",
       "type": "control_catalog",
       "path": "controls/control-catalog.json",

--- a/docs/maintainers/repository-maintenance.md
+++ b/docs/maintainers/repository-maintenance.md
@@ -6,7 +6,7 @@ This document keeps the guide coherent as research, controls, templates, example
 
 | Layer | Authority | Change obligation |
 | --- | --- | --- |
-| `guide/` | Concise human mental model and route into deeper artifacts | Stay linear, readable, non-normative, consistent with the lifecycle, and free of duplicated contract detail |
+| `guide/` | Concise human mental model plus role and practice orientation | Keep the core method linear; keep the capability roadmap non-normative, evidence-oriented, and free of duplicated contract detail or certification claims |
 | `.agents/skills/` | Focused human- and agent-readable task routes | Keep triggers distinct, procedures thin, outputs explicit, metadata valid, and links bound to canonical artifacts |
 | `research/` | Dated evidence and caveats | Verify source, date, attribution, and claim boundary |
 | `controls/` | Normative project requirements | Link evidence and release gates; update affected verification |
@@ -66,7 +66,7 @@ This document keeps the guide coherent as research, controls, templates, example
 2. Run `npm ci --ignore-scripts`, `npm test`, and `git diff --check`; `npm test` includes solution, value-framework, skill-metadata, site-build, link, metadata, and catalog checks.
 3. Run spelling, action workflow, dependency, and secret scans used by the current project.
 4. Confirm all new governed artifacts are cataloged and every new source ID resolves.
-5. Proofread README, concise Guide, AGENTS, llms, generated site routes and descriptions, playbook routes, changelog, package/citation versions, and release links.
+5. Proofread README, concise Guide, capability roadmap, AGENTS, llms, generated site routes and descriptions, playbook routes, changelog, package/citation versions, and release links.
 6. When skill discovery or packaging changes, verify `npx skills add davidahmann/fde-guide --list` from a disposable environment; do not add this network-dependent smoke test to the deterministic CI gate.
 7. Use a scoped commit and draft pull request; do not bypass protected `main`.
 8. Require CI and review before merge; tag only after the release tree and metadata agree.

--- a/guide/README.md
+++ b/guide/README.md
@@ -6,6 +6,8 @@ This is the concise human guide to forward-deployed engineering and internal app
 
 **Reading time:** about 20 minutes. This guide is narrative orientation, not a production standard or a substitute for the target organization's policy, security, architecture, or risk review.
 
+If you are learning the role, planning a development path, or assessing a team, use the companion [FDE and AI Engineer Capability Roadmap](capability-roadmap.md). It turns this method into role boundaries, capability evidence, four practice missions, a quick-start pack, and a glossary without creating a second methodology.
+
 ## 1. What an FDE is responsible for
 
 A forward-deployed engineer turns an ambiguous operating problem into a supported software service that produces a measurable outcome. The work crosses four responsibilities:
@@ -295,6 +297,7 @@ If a consequential answer is missing, stay in discovery. A model or framework ch
 
 Choose the depth that matches the work:
 
+- **Build capability:** use the [FDE and AI Engineer Capability Roadmap](capability-roadmap.md), complete one bounded mission, and keep the resulting limitations visible.
 - **Run the method:** use the [FDE Handbook](../playbooks/README.md) and follow the current lifecycle stage.
 - **Design a recurring solution:** start from the [business-flow portfolio](../solutions/README.md), then select only the relevant vertical profile and horizontal foundation.
 - **Build or review a system:** use the [Engineering Kit](../templates/README.md), [controls](../controls/control-catalog.json), [schemas](../schemas/README.md), [blueprints](../blueprints/README.md), [examples](../examples/invoice-exception/README.md), and [tests](../tests/).

--- a/guide/capability-roadmap.md
+++ b/guide/capability-roadmap.md
@@ -1,0 +1,165 @@
+# Forward Deployed Engineer and AI Engineer Capability Roadmap
+
+> Learn the responsibilities by completing evidence-backed missions, not by memorizing a preferred stack.
+
+This roadmap is for people growing into forward-deployed engineering (FDE), applied-AI engineering, or adjacent delivery roles—and for leaders deciding what capability a team needs. It complements the [concise FDE Guide](README.md): the Guide explains the method; this page organizes the capabilities needed to apply it.
+
+It is not a certification, hiring standard, fixed curriculum, or claim that one title owns every responsibility. Titles and team boundaries vary. Evaluate the work, authority, evidence, and operating responsibility instead.
+
+## Choose the responsibility, not the title
+
+These roles overlap. The useful distinction is what each person remains accountable for after a design meeting or customer workshop ends.
+
+| Role | Primary accountability | Evidence of good work | Boundary to clarify |
+| --- | --- | --- | --- |
+| Forward-deployed engineer | Turn a target workflow into a measurable, supported capability in its real environment | Observed cases, bounded value contract, integrated system, accepted outcomes, adoption, and exercised handoff | Which work belongs in the shared product, the target environment, or a time-bounded experiment |
+| Applied-AI or AI engineer | Build and improve production AI-enabled behavior inside a product, platform, or internal workflow | Mechanism choice, data and behavior versions, evaluations, software boundaries, telemetry, and regression evidence | Whether the role owns workflow discovery, product decisions, deployment, and ongoing service outcomes |
+| Software or platform engineer | Build reliable product and platform capabilities that remain maintainable across users and environments | Code, contracts, tests, releases, service objectives, incident recovery, and operational ownership | Which target-specific context should become configuration, an extension, or no shared feature at all |
+| Solutions engineer or architect | Translate requirements and constraints into a viable integration and adoption design | Architecture decisions, technical validation, integration plan, risk decisions, and stakeholder alignment | Who owns implementation, production effects, acceptance evidence, and support after launch |
+| Implementation or professional-services engineer | Deliver a defined outcome within commercial, technical, and schedule boundaries | Scoped delivery, configuration, migration, enablement, acceptance, and transition evidence | Whether recurring field work has a normal path into product or platform ownership |
+
+No role receives authority merely from its title. Production access, approvals, release decisions, customer commitments, and risk acceptance still belong to the target system and its accountable owners.
+
+## The capability map
+
+The work moves through one operating loop. Software, data, security, product judgment, and communication support every stage rather than forming separate tracks.
+
+```mermaid
+flowchart LR
+    O["Observe the work"] --> V["Engineer value"]
+    V --> M["Select the mechanism"]
+    M --> B["Build and integrate"]
+    B --> P["Prove and release"]
+    P --> R["Operate and transfer"]
+    R --> L["Productize learning"]
+    L --> O
+
+    F["Software · data · security · product · communication"] --- O
+    F --- M
+    F --- P
+    F --- R
+```
+
+| Capability | You can do the work when you can… | Inspectable evidence |
+| --- | --- | --- |
+| Workflow discovery | Reconstruct real cases, exceptions, workarounds, actors, sources, decisions, and recovery without treating interviews as proof | [Observation log](../templates/field-observation-log.md), [discovery pack](../templates/fde-discovery-pack.md), owner validation |
+| Value and product judgment | Define the eligible population, baseline, accepted outcome, verifier, full cost, guardrails, adoption path, and stop decision | [Workflow charter](../templates/workflow-charter.json), [value case](../templates/value-case.md), [12 Factors](../library/14-twelve-factors-ai-value-engineering.md) |
+| Software and data architecture | Establish domain state, source-of-truth boundaries, integration contracts, failure ownership, change paths, and supportability | [Operational ontology](../templates/operational-ontology.json), [architecture decision](../templates/architecture-decision-record.md), [blueprints](../blueprints/README.md) |
+| Intelligence selection | Compare deterministic software, optimization, classical ML, retrieval, model calls, agents, and human review for each consequential decision | [Intelligence-selection record](../templates/intelligence-selection-record.md), [hybrid reference](../examples/shipment-risk-triage/README.md) |
+| Secure integration and action | Bind identity, tenant, data, credential, egress, authorization, duplicate safety, and verification below model output | [Security guide](../library/15-production-ai-security-and-action-boundaries.md), [tool contract](../templates/tool-contract.json), [controlled-write reference](../examples/invoice-exception/README.md) |
+| Evaluation and release | Turn a bounded claim into representative, adversarial, repeatable cases and release only the exact tested system | [Evaluation case](../templates/evaluation-case.json), [release gates](../operations/release-gates.md), applicable release evidence |
+| Adoption and operation | Design the work surface, rollout, telemetry, support, incident response, cost control, ownership, and retirement path | [Delivery and adoption plan](../templates/delivery-and-adoption-plan.md), [operations](../operations/README.md), [service review](../templates/production-service-review.md) |
+| Transfer and field learning | Prove the receiving team can change and recover the service, then separate local context from reusable capability | [Customer handoff](../templates/customer-enablement-handoff.md), [field-learning register](../templates/field-learning-register.md), [product boundaries](../library/10-fde-and-production-agent-synthesis.md) |
+
+Breadth matters, but no one must be the deepest specialist in every domain. A strong practitioner recognizes missing expertise, assigns owners, exposes assumptions, and prevents an unowned gap from becoming hidden production risk.
+
+## Four practice missions
+
+Use these missions in order when learning the method. On real work, enter at the current lifecycle stage and preserve prior evidence. A repository exercise demonstrates reasoning and implementation technique; it does not substitute for production experience, user acceptance, or target-system approval.
+
+### Mission 1: qualify a real workflow
+
+Choose one bounded workflow you can observe. Do not begin with an agent idea.
+
+1. Walk through at least three representative cases, including an exception or recovery path.
+2. Record the trigger, decision, working interface, actors, sources, permitted action, current result, and owner.
+3. Define an accepted outcome and credible verifier.
+4. Estimate the eligible population, baseline, full cost, residual loss, and adoption constraints.
+5. Decide `discover`, `defer`, or `do_not_build`; recommend `pilot` only after the value case is plausible.
+
+**Finish with:** an [observation log](../templates/field-observation-log.md), [workflow charter](../templates/workflow-charter.json), and [value case](../templates/value-case.md) another person can challenge.
+
+### Mission 2: design the smallest sufficient system
+
+Use the [shipment-risk walkthrough](../examples/shipment-risk-triage/README.md) as a reference for separating mechanisms.
+
+1. Decompose the workflow into consequential decision steps.
+2. Compare rules, optimization, classical ML, retrieval, model calls, agents, and human review per step.
+3. Draw the domain, state, source, identity, and failure boundaries.
+4. Select one end-to-end slice that can be accepted or safely rejected.
+5. Record what remains manual and why.
+
+**Finish with:** an [intelligence-selection record](../templates/intelligence-selection-record.md), architecture decision, domain model, and a tested slice whose complexity is justified by the workflow.
+
+### Mission 3: secure and verify a consequential action
+
+Use the [invoice-exception reference](../examples/invoice-exception/README.md) to inspect a controlled write.
+
+1. Define a narrow typed read or effect contract.
+2. Enforce caller identity, tenant, scope, policy, credentials, destination, and data class at the trusted boundary.
+3. Give the business operation a stable duplicate-safe identity.
+4. Add approval only where required; bind it to the exact proposal and current policy.
+5. Verify the source of truth after the effect and reconcile effect-unknown outcomes.
+6. Test denial, revocation, retry, stale state, cross-tenant access, receipt tampering, timeout, and recovery.
+
+**Finish with:** executable positive and adversarial tests, an explicit threat model, and a release claim no broader than the tested behavior.
+
+### Mission 4: operate and transfer the service
+
+Treat launch as the start of a recurring decision.
+
+1. Define accepted-outcome, adoption, reliability, safety, cost, and reviewer-load measures with owners and denominators.
+2. Exercise alerting, containment, rollback, recovery, and a material change.
+3. Run a service review that can continue, constrain, pause, or retire the system.
+4. Have the receiving team perform a change and recovery without delivery-team intervention.
+5. Record recurring field learning without copying customer policy, data, identities, or confidential context.
+
+**Finish with:** an exercised [service review](../templates/production-service-review.md), [customer handoff](../templates/customer-enablement-handoff.md), and owned improvement or retirement decision.
+
+## The quick-start engagement pack
+
+Do not copy every template before the workflow earns that complexity. Start with five linked decisions and expand only when the target system requires it.
+
+| Decision | Start with | Add when needed |
+| --- | --- | --- |
+| What work is changing? | [Observation log](../templates/field-observation-log.md) | Discovery pack for stakeholder, source, constraint, and readiness detail |
+| Is it worth changing? | [Workflow charter](../templates/workflow-charter.json) and [value case](../templates/value-case.md) | Adoption evidence, attribution design, portfolio comparison |
+| What should make each decision? | [Intelligence-selection record](../templates/intelligence-selection-record.md) | Architecture decisions, domain model, system map, applicable blueprint |
+| Can one slice work safely? | [Delivery and adoption plan](../templates/delivery-and-adoption-plan.md) and realistic evaluation cases | Tool, capability, behavior, threat, telemetry, and release contracts |
+| Can the owning team run it? | [Customer handoff](../templates/customer-enablement-handoff.md) and [service review](../templates/production-service-review.md) | Incident exercises, change evidence, portfolio and field-learning records |
+
+This pack is an orientation subset, not a production-complete packet. Use the full [artifact sequence](../AGENTS.md#artifact-sequence-for-a-new-system) when designing or reviewing a real system.
+
+## How to assess capability
+
+Whether reviewing yourself, a candidate, or a delivery team, ask for decisions and evidence rather than tool-name recall.
+
+- Can they reconstruct a workflow from cases and recognize when not to build?
+- Can they connect an accepted outcome to a verifier, value case, and accountable owner?
+- Can they choose a smaller mechanism than an agent when it is sufficient?
+- Can they explain source, identity, tenant, authority, failure, and recovery boundaries?
+- Can they turn a claim into representative and adversarial tests?
+- Can they operate within cost and reliability limits and respond to effect-unknown state?
+- Can the receiving team change, recover, support, and retire the service without them?
+- Can they convert recurring learning into a shared capability without leaking target-specific context?
+
+A polished demo or diagram can start the conversation. It cannot prove production readiness, customer impact, security, or operating capability.
+
+## Concise glossary
+
+| Term | Meaning in this guide |
+| --- | --- |
+| Accepted outcome | A business or operating event independently recognized as a valid result—not merely a generated answer, completed agent run, or tool response |
+| Eligible population | The work that could validly enter the workflow, including explicit exclusions and a denominator for measurement |
+| Verifier | The person, deterministic rule, reconciliation, or source-of-truth event that can establish whether an outcome was accepted |
+| Workflow boundary | The trigger, decision, actors, inputs, working interface, permitted action, result, exceptions, recovery, and owner included in scope |
+| Smallest sufficient mechanism | The least complex combination of software, optimization, ML, retrieval, model behavior, agency, and human review that can meet the evidence and operating requirements |
+| Operational ontology | A versioned domain and state model for relevant entities, actions, evidence, transitions, invariants, and policy references; it is not an authorization system by itself |
+| Tool contract | A closed interface describing one bounded read, computation, stage, or effect, including data, identity, authorization, failure, and verification behavior |
+| Capability manifest | Provenance and admitted-authority evidence for the exact executable capability behind a tool contract |
+| Consequential effect | A change to an external system or obligation whose authority, duplicate safety, result, and recovery must be enforced below model output |
+| Readback | A fresh source-of-truth verification of the postcondition after a consequential effect; a successful API response alone is not readback |
+| Evaluation case | A versioned world, input, expected invariants, graders, budgets, and failure conditions used to test a bounded claim |
+| Release evidence | The exact versions, digests, compatibility, evaluation, approval, rollout, rollback, and operating evidence for the system being admitted |
+| Handoff | Demonstrated receiving-team capability to operate, change, evaluate, release, recover, support, and retire the service |
+| Field learning | Sanitized, evidence-backed knowledge from delivery that may become a pattern, product capability, platform improvement, control, or configuration after recurrence and ownership are established |
+
+## Continue into the method
+
+- Read the [concise FDE Guide](README.md) for the complete mental model.
+- Follow the [FDE lifecycle playbooks](../playbooks/README.md) for a live engagement.
+- Start from [business-flow patterns](../solutions/README.md) only after qualification and value work.
+- Inspect the [executable references](../examples/invoice-exception/README.md) and [Engineering Kit](../templates/README.md) when implementation evidence is needed.
+- Give a coding agent [AGENTS.md](../AGENTS.md) or use one optional [task skill](../.agents/skills/) for a bounded job.
+
+The goal is not to become indispensable to a deployment. It is to leave behind an owned capability that produces accepted value and can be changed, recovered, and retired without delivery-team heroics.

--- a/llms.txt
+++ b/llms.txt
@@ -11,6 +11,7 @@ Read [AGENTS.md](AGENTS.md) before modifying this repository.
 - Human overview: [README.md](README.md)
 - Searchable web guide: [The FDE Guide](https://davidahmann.github.io/fde-guide/)
 - Concise linear FDE Guide: [guide/README.md](guide/README.md)
+- FDE and AI engineer capability roadmap: [guide/capability-roadmap.md](guide/capability-roadmap.md)
 - Agent editing and routing contract: [AGENTS.md](AGENTS.md)
 - Governed-artifact registry: [catalog.json](catalog.json)
 - Production controls: [controls/control-catalog.json](controls/control-catalog.json)

--- a/scripts/validate-repository.mjs
+++ b/scripts/validate-repository.mjs
@@ -340,6 +340,7 @@ const requiredPublicFiles = [
   ".github/ISSUE_TEMPLATE/config.yml",
   ".github/ISSUE_TEMPLATE/design-proposal.yml",
   ".github/ISSUE_TEMPLATE/evidence-correction.yml",
+  ".github/ISSUE_TEMPLATE/field-signal.yml",
   ".github/PULL_REQUEST_TEMPLATE.md",
   ".github/dependabot.yml",
   ".github/workflows/pages.yml",

--- a/site/site.config.mjs
+++ b/site/site.config.mjs
@@ -14,7 +14,12 @@ export const site = {
 export const navigation = [
   {
     label: "Start",
-    routes: ["/", "/forward-deployed-engineering/", "/fde-operating-model/"],
+    routes: [
+      "/",
+      "/forward-deployed-engineering/",
+      "/forward-deployed-engineer-roadmap/",
+      "/fde-operating-model/",
+    ],
   },
   {
     label: "Design",
@@ -61,6 +66,14 @@ export const pages = [
     title: "Forward Deployed Engineer Guide: From Workflow to Production",
     description:
       "Learn what forward deployed engineers do and how to move a real workflow from discovery to measurable, business-owned operation.",
+  },
+  {
+    route: "/forward-deployed-engineer-roadmap/",
+    source: "guide/capability-roadmap.md",
+    navTitle: "FDE capability roadmap",
+    title: "Forward Deployed Engineer Roadmap: Skills, Missions, and Evidence",
+    description:
+      "A practical capability roadmap for forward deployed and applied AI engineers, with role boundaries, four missions, starter artifacts, and a glossary.",
   },
   {
     route: "/fde-operating-model/",

--- a/tests/site.test.mjs
+++ b/tests/site.test.mjs
@@ -28,6 +28,23 @@ test("site configuration defines one canonical source per route", () => {
   }
 });
 
+test("the capability roadmap is a bounded secondary entry layer", async () => {
+  const page = pages.find(({ source }) => source === "guide/capability-roadmap.md");
+  assert.equal(page?.route, "/forward-deployed-engineer-roadmap/");
+  const source = await readFile(path.join(root, page.source), "utf8");
+  for (const heading of [
+    "## Choose the responsibility, not the title",
+    "## The capability map",
+    "## Four practice missions",
+    "## The quick-start engagement pack",
+    "## Concise glossary",
+  ]) {
+    assert.ok(source.includes(heading), heading);
+  }
+  assert.match(source, /not a certification, hiring standard, fixed curriculum/);
+  assert.match(source, /does not substitute for production experience, user acceptance, or target-system approval/);
+});
+
 test("every canonical page has accessible structure and complete metadata", async () => {
   const canonicals = [];
   for (const page of pages) {


### PR DESCRIPTION
## Summary

- add one compact capability roadmap for forward-deployed and applied-AI engineering
- compare adjacent role responsibilities and organize the method into eight evidence-backed capability domains
- provide four practice missions, a five-part engagement starter pack, assessment prompts, and a concise glossary
- publish the roadmap as a canonical Pages route and connect README, Guide, AGENTS, llms, catalog, support, and maintainer navigation
- add a low-friction field-signal issue form with confidentiality and evidence boundaries

## Design boundary

The roadmap is a secondary learning layer over the existing method. It is explicitly not a certification, hiring standard, production gate, or separate framework. It does not replace target evidence, controls, schemas, release review, or operating ownership.

## Validation

- `npm ci --ignore-scripts`
- `npm test`
- `git diff --check`
- `actionlint .github/workflows/*.yml`
- `npm audit --audit-level=high`
- YAML parse of every issue form
- desktop and mobile browser QA of the generated route
- staged secret scan
