### PR TITLE
Add measured multi-agent topology guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Notable changes to this project are recorded here.
 
 ## [Unreleased]
 
+- Add controlled evidence and matched-budget guidance for admitting, selecting, re-evaluating, and retiring multi-agent topologies without treating a benchmark threshold as a universal release gate.
+
 ## [1.16.0] - 2026-08-12
 
 - Add a decision-scoped data-readiness method that separates operational, knowledge/context, evaluation/training, and telemetry/feedback planes across discovery, design, evaluation, release, and operation.

--- a/blueprints/multi-agent-coordinator.md
+++ b/blueprints/multi-agent-coordinator.md
@@ -11,6 +11,18 @@ At least one MUST be true:
 
 Before admission, run the same representative suite through a serial single-agent or deterministic baseline. Record task success, safety, latency, cost, review load, and failure isolation. Parallel or specialist decomposition is accepted only when the measured benefit exceeds coordination cost and introduces no unresolved authority or merge ambiguity (`ARC-004`).
 
+## Measured topology selection
+
+Treat published thresholds as priors, not release gates. A 2026 controlled study found that a single-agent baseline near 45% was useful for predicting zero-to-negative multi-agent gains within the tested domains, but the result does not generalize into a universal cutoff. Low baseline performance alone also does not justify fan-out. [R26-75](../research/2026-08-14--multi-agent-topology-selection.md#r26-75)
+
+For every candidate topology:
+
+- Keep deterministic, coded-workflow, and serial single-agent paths as live controls.
+- Hold the representative cases, prompts, tools, and total compute budget constant; use repeated trials where model behavior is selected.
+- Start sequentially dependent work on the serial path. Test fan-out only when work decomposes cleanly or workers need genuinely different context, permissions, tools, ownership, specialization, or latency.
+- Compare accepted outcome, safety, latency, full cost, review load, and failure isolation—not final-answer quality alone.
+- Rerun the comparison after changing the model, prompt, context policy, tool set, topology, or verifier, and retire coordination when it no longer wins.
+
 ## Components
 
 ```mermaid
@@ -111,7 +123,7 @@ The atomic claim is the execution admission record. A concurrent or post-restart
 11. Successful root and nested consumption through authoritative parent and recipient resolution.
 12. Concurrent and post-restart replay returns `already_claimed` without second admission.
 13. Unavailable verifier or atomic claim service fails closed.
-14. Serial baseline comparison and admission decision.
+14. Matched-budget serial baseline comparison and topology admission or retirement decision.
 15. Malformed, over-scoped, stale, and tainted context-handoff rejection.
 
 ## Controls

--- a/catalog.json
+++ b/catalog.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schemas/artifact-catalog.schema.json",
   "schema_version": "1.1.0",
-  "updated": "2026-08-12",
+  "updated": "2026-08-14",
   "artifacts": [
     {
       "id": "guide.core",
@@ -698,6 +698,12 @@
       "type": "evidence",
       "path": "research/2026-08-11--multimodal-operations-and-computer-use.md",
       "tags": ["sources", "computer-use", "multimodal", "evaluation"]
+    },
+    {
+      "id": "evidence.multi-agent-topology-selection",
+      "type": "evidence",
+      "path": "research/2026-08-14--multi-agent-topology-selection.md",
+      "tags": ["sources", "multi-agent", "architecture", "evaluation"]
     }
   ]
 }

--- a/library/03-agent-system-architecture.md
+++ b/library/03-agent-system-architecture.md
@@ -115,6 +115,8 @@ Do not formalize a large graph before observing real traces. Start with a capabl
 
 Multi-agent design is not automatically more capable. It is useful when tasks are truly independent, specialists need different context or tools, or parallel work reduces elapsed time. Hex's effort to unify notebook and thread agents around a common harness, tool bundles, and context harvesting suggests that shared infrastructure matters more than agent count. [S02]
 
+A 2026 controlled evaluation reinforces this selection rule rather than supplying a universal topology. Across 260 matched configurations, multi-agent performance ranged from +80.8% on decomposable financial analysis to −70.0% on sequential planning, while the overall mean change was −0.3%. A single-agent score near 45% was useful as a within-domain selection heuristic, not a release gate. Keep the simpler path as a live control, compare total budgets on representative work, and retire coordination when it no longer earns its cost. [R26-75](../research/2026-08-14--multi-agent-topology-selection.md#r26-75)
+
 ## Event-sourced execution
 
 The event-sourced workshop and HumanLayer's stateless-reducer principle converge on a useful runtime shape:

--- a/patterns/pattern-catalog.json
+++ b/patterns/pattern-catalog.json
@@ -354,13 +354,13 @@
       "status": "accepted",
       "maturity": "normative",
       "applies_when": ["multiple agents share the same context, tools, permissions, and sequential workflow"],
-      "implementation": ["replace with one bounded agent or deterministic workflow unless an admission criterion is met"],
-      "control_ids": ["ARC-001", "ARC-003", "REL-004"],
-      "failure_signals": ["coordination cost, duplicated work, unresolved conflicts, and cancellation leaks"],
-      "verification": ["single-agent baseline is measured before decomposition"],
-      "evidence": ["R26-10", "R26-29", "R26-31"],
-      "reviewed_at": "2026-08-07",
-      "review_due": "2027-02-07"
+      "implementation": ["replace with one bounded agent or deterministic workflow unless an admission criterion is met", "admit a topology only when repeated, matched-budget evaluation on representative work beats the simpler control without unresolved authority or merge ambiguity"],
+      "control_ids": ["ARC-001", "ARC-003", "ARC-004", "REL-004"],
+      "failure_signals": ["coordination cost, duplicated work, unresolved conflicts, cancellation leaks, or regression against the simpler baseline"],
+      "verification": ["deterministic or coded-workflow and single-agent baselines are measured before decomposition and retained as controls after behavior or topology changes"],
+      "evidence": ["R26-10", "R26-29", "R26-31", "R26-75"],
+      "reviewed_at": "2026-08-14",
+      "review_due": "2027-02-14"
     },
     {
       "id": "ANTI-006",

--- a/research/2026-08-14--multi-agent-topology-selection.md
+++ b/research/2026-08-14--multi-agent-topology-selection.md
@@ -1,0 +1,14 @@
+# Multi-Agent Topology Selection Evidence
+
+Reviewed 2026-08-14. This note records one controlled architecture study as evidence for local evaluation design. It does not establish a universal agent-count or topology rule.
+
+<a id="r26-75"></a>
+## R26-75 — Kim et al.: coordination gains depend on task–topology fit
+
+- **Date:** Published 2026-07-24; reviewed 2026-08-14
+- **Type / tier:** Peer-reviewed controlled evaluation with a public manuscript; B
+- **Sources:** [Capable language models can outgrow the benefits of collaboration](https://www.nature.com/articles/s42256-026-01268-y) and [public manuscript](https://arxiv.org/abs/2512.08296)
+- **Finding:** Across 260 configurations spanning six agentic benchmarks, five architectures, and three model families, the researchers standardized prompts, tools, and compute while varying coordination structure and model capability. Multi-agent performance relative to the single-agent baseline ranged from +80.8% on decomposable financial analysis to −70.0% on sequential planning; the overall mean change was −0.3%. The single-agent baseline was the most robust predictor, while a separately fitted threshold near 45% served as a within-domain selection rule. Trace analysis measured 17.2× error amplification for independent aggregation and 4.4× for centralized coordination with a verification bottleneck.
+- **Portable pattern:** Keep deterministic, coded-workflow, and serial single-agent baselines as live controls. Compare candidate topologies on representative target work under matched prompts, tools, total compute, and repeated trials; score accepted outcome, safety, latency, full cost, review load, and failure isolation. Prefer serial execution for sequentially dependent work, and admit fan-out only when decomposition or a real context, permission, specialization, ownership, or latency boundary earns the coordination cost. Rerun the comparison when a model, prompt, tool, context policy, or topology changes.
+- **Anti-pattern:** Treating 45% as a universal release threshold, assuming a weak single-agent result automatically justifies a supervisor or crew, or using an aggregate benchmark mean to choose a production topology.
+- **Caveat:** The study covers six benchmark clusters. Its threshold and architecture rankings are practical within-domain priors, not portable scaling laws or substitutes for target-workflow evaluation; the paper reports weak absolute generalization to unseen domains.

--- a/research/README.md
+++ b/research/README.md
@@ -2,7 +2,7 @@
 
 This folder holds dated evidence that supports the implementation library.
 
-**Repository source review:** 2026-08-10. For the current dated ledger and solution evidence notes, source location, publication date, attribution, and evidence tier were rechecked. Link reachability and first-party publication do not establish general validity; every implementation pattern still requires local evaluation.
+**Repository source review:** The general source set was last rechecked 2026-08-10; the multi-agent topology note was reviewed 2026-08-14. Link reachability and first-party publication do not establish general validity; every implementation pattern still requires local evaluation.
 
 ## How sources are admitted
 
@@ -26,6 +26,7 @@ Social, Reddit, YouTube, and news are research channels—not automatic authorit
 - [FDE commercial and professional-practice note](2026-08-09--fde-commercial-and-professional-practice.md) — secondary-source leads for pilot graduation, continuation health, delivery-portfolio economics, responsible reuse, and professional boundaries; excludes copied content, commercial adaptation, benchmarks, and pricing doctrine.
 - [FDE product-boundaries and capability-transfer note](2026-08-10--fde-product-boundaries-and-capability-transfer.md) — directly inspectable practitioner evidence for contribution zones, product feedback, shadow-product avoidance, receiving-team capability, and reuse-rights decisions, with organizational claims kept non-normative.
 - [Multimodal operations and computer-use boundaries](2026-08-11--multimodal-operations-and-computer-use.md) — attributed field evidence for long-running multimodal work, reference-label authority, and browser/desktop action boundaries, with vendor metrics and an insurance vertical profile explicitly deferred.
+- [Multi-agent topology selection evidence](2026-08-14--multi-agent-topology-selection.md) — controlled evidence for matched-budget single-agent and multi-agent comparison, topology-dependent performance, error containment, and limits on portable thresholds.
 
 ## Archive
 

--- a/tests/schema-contracts.test.mjs
+++ b/tests/schema-contracts.test.mjs
@@ -599,12 +599,12 @@ test("ontology identity keys resolve to declared attributes", async () => {
 test("pattern catalogs require unique IDs, defined evidence, and ordered current review dates", async () => {
   const fixture = await json("patterns/pattern-catalog.json");
   const evidenceIds = new Set(fixture.patterns.flatMap((pattern) => pattern.evidence).filter((id) => !id.startsWith("internal-")));
-  const reviewDate = new Date("2026-08-11T12:00:00Z");
+  const reviewDate = new Date("2026-08-14T12:00:00Z");
   assert.deepEqual(patternCatalogErrors(fixture, evidenceIds, "fixture", reviewDate), []);
 
   fixture.patterns[1].id = fixture.patterns[0].id;
   fixture.patterns[0].evidence = ["R26-99"];
-  fixture.patterns[0].reviewed_at = "2026-08-12";
+  fixture.patterns[0].reviewed_at = "2026-08-15";
   fixture.patterns[1].review_due = "2026-08-06";
   const errors = patternCatalogErrors(fixture, evidenceIds, "fixture", reviewDate);
   assert.ok(errors.some((error) => error.includes("duplicates pattern ID")));


### PR DESCRIPTION
## Problem

The guide already requires a serial baseline before multi-agent decomposition, but it did not incorporate the July 2026 controlled evidence on task–topology fit, matched-budget comparison, capability saturation, or topology-dependent error amplification.

## Changes

- add a dated, cataloged research note for the Nature Machine Intelligence study
- clarify that the roughly 45% single-agent threshold is a within-domain prior, not a universal gate
- require matched-budget controls, repeated trials, full-cost comparison, re-evaluation, and retirement in the coordinator blueprint
- strengthen the existing multi-agent-by-default anti-pattern and advance its review-date fixture
- document the update in the Unreleased changelog

## Validation

- `npm ci --ignore-scripts`
- `npm test`
- `git diff --check`
- focused repository, Markdown, contract, and site checks
- dependency audit: 0 vulnerabilities

## Risk

Documentation and validation-fixture change only. No runtime, schema, control, or release behavior changes.
